### PR TITLE
LIDとLnをbranded typesにした

### DIFF
--- a/packages/Reditor/src/Cursor/model.ts
+++ b/packages/Reditor/src/Cursor/model.ts
@@ -1,5 +1,5 @@
 import { atom, DefaultValue, selector } from 'recoil';
-import { Pos } from '../Shared/typings';
+import { Ln, Pos } from '../Shared/typings';
 
 // -------------------------------------------------------------------------------------
 // Types
@@ -26,9 +26,9 @@ export const cursorFocusS = atom({
   default: false,
 });
 
-export const cursorLnS = atom({
+export const cursorLnS = atom<Ln>({
   key: 'cursorLnS',
-  default: 0,
+  default: Ln(0),
 });
 
 export const cursorColS = atom({

--- a/packages/Reditor/src/Cursor/test/useCursorKeymap.test.ts
+++ b/packages/Reditor/src/Cursor/test/useCursorKeymap.test.ts
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react-hooks';
+import { act } from '@testing-library/react-hooks/dom';
 import { useRecoilValue } from 'recoil';
 import { useCursorKeymap, cursorLnS, cursorColS } from '..';
 import { renderRecoilHook } from '../../Shared';

--- a/packages/Reditor/src/Cursor/useCursorKeymap.ts
+++ b/packages/Reditor/src/Cursor/useCursorKeymap.ts
@@ -1,4 +1,5 @@
 import { useRecoilCallback } from 'recoil';
+import { Ln } from '../Shared';
 import { decN } from '../Shared/functions';
 import { cursorLnS, cursorColS } from './model';
 
@@ -8,7 +9,7 @@ import { cursorLnS, cursorColS } from './model';
 export const useCursorKeymap = () => {
   const up = useRecoilCallback(
     ({ set }) => () => {
-      set(cursorLnS, ln => decN(ln, 1));
+      set(cursorLnS, ln => Ln(decN(ln, 1)));
     },
     [],
   );
@@ -22,7 +23,7 @@ export const useCursorKeymap = () => {
 
   const down = useRecoilCallback(
     ({ set }) => () => {
-      set(cursorLnS, ln => ln + 1);
+      set(cursorLnS, ln => Ln(ln + 1));
     },
     [],
   );

--- a/packages/Reditor/src/FocusedLine/model.ts
+++ b/packages/Reditor/src/FocusedLine/model.ts
@@ -1,6 +1,6 @@
 import { selector, useRecoilCallback } from 'recoil';
 import { cursorLnS } from '../Cursor';
-import { lineIdsS, noteLineS } from '../Note';
+import { displayLids, noteLineS } from '../Note';
 import { deleteNthChar, insertNthChar } from '../Shared/functions';
 
 // -------------------------------------------------------------------------------------
@@ -12,8 +12,8 @@ export const focuedLineS = selector<string>({
   get: ({ get }) => {
     return get(
       noteLineS({
-        noteId: 0,
-        lineId: get(lineIdsS(0))[get(cursorLnS)],
+        noteId: 0, // FIXME:
+        lid: get(displayLids(0))[get(cursorLnS)],
       }),
     );
   },
@@ -21,7 +21,7 @@ export const focuedLineS = selector<string>({
     set(
       noteLineS({
         noteId: 0, // FIXME:
-        lineId: get(lineIdsS(0))[get(cursorLnS)],
+        lid: get(displayLids(0))[get(cursorLnS)],
       }),
       value,
     );

--- a/packages/Reditor/src/FocusedLine/test/model.test.ts
+++ b/packages/Reditor/src/FocusedLine/test/model.test.ts
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react-hooks';
+import { act } from '@testing-library/react-hooks/dom';
 import { useRecoilState } from 'recoil';
 import { focuedLineS, useFocuedLine } from '..';
 import { renderRecoilHook } from '../../Shared';

--- a/packages/Reditor/src/Note/test/line.test.ts
+++ b/packages/Reditor/src/Note/test/line.test.ts
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react-hooks';
+import { act } from '@testing-library/react-hooks/dom';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { Ln, renderRecoilHook } from '../../Shared';
 import { displayLids, noteLinesS, useLines } from '..';

--- a/packages/Reditor/src/Note/test/line.test.ts
+++ b/packages/Reditor/src/Note/test/line.test.ts
@@ -1,12 +1,12 @@
 import { act } from '@testing-library/react-hooks';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import { renderRecoilHook } from '../../Shared';
-import { lineIdsS, noteLinesS, useLines } from '..';
+import { Ln, renderRecoilHook } from '../../Shared';
+import { displayLids, noteLinesS, useLines } from '..';
 
 const useMock = () => {
   const noteId = 0;
 
-  const lineIds = useRecoilValue(lineIdsS(noteId));
+  const lineIds = useRecoilValue(displayLids(noteId));
   const f = useLines(noteId);
   const [lines, setLines] = useRecoilState(noteLinesS(noteId));
 
@@ -34,7 +34,7 @@ describe('useLines', () => {
     });
 
     await act(async () => {
-      result.current.f.updateLine(0, 'hogehoge');
+      result.current.f.updateLine(Ln(0), 'hogehoge');
       await waitForNextUpdate();
     });
     expect(result.current.lines).toStrictEqual(['hogehoge', 'ijklmno']);
@@ -55,7 +55,7 @@ describe('useLines', () => {
     });
 
     await act(async () => {
-      result.current.f.newLine(1, 3);
+      result.current.f.newLine(Ln(1), 3);
       await waitForNextUpdate();
     });
     expect(result.current.lines).toStrictEqual([
@@ -82,7 +82,7 @@ it('removeLine', async () => {
   });
 
   await act(async () => {
-    result.current.f.removeLine(1);
+    result.current.f.removeLine(Ln(1));
     await waitForNextUpdate();
   });
   expect(result.current.lines).toStrictEqual(['aaabbb']);

--- a/packages/Reditor/src/Note/test/useNotOp.test.ts
+++ b/packages/Reditor/src/Note/test/useNotOp.test.ts
@@ -1,6 +1,6 @@
 import { act } from '@testing-library/react-hooks';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import { renderRecoilHook } from '../../Shared';
+import { Ln, renderRecoilHook } from '../../Shared';
 import { cursorPosS } from '../../Cursor';
 import { noteLinesS, useNoteOp } from '..';
 import { focuedLineS } from '../../FocusedLine';
@@ -23,7 +23,7 @@ describe('useNoteOp', () => {
     // initialize
     act(() => {
       result.current.setLines(['abc']);
-      result.current.setPos({ ln: 0, col: 2 }); // ab|c
+      result.current.setPos({ ln: Ln(0), col: 2 }); // ab|c
     });
 
     await act(async () => {
@@ -41,7 +41,7 @@ describe('useNoteOp', () => {
     // initialize
     act(() => {
       result.current.setLines(['aaa', 'bbb', 'ccc']);
-      result.current.setPos({ ln: 1, col: 2 }); // bb|b
+      result.current.setPos({ ln: Ln(1), col: 2 }); // bb|b
     });
 
     await act(async () => {
@@ -59,7 +59,7 @@ describe('useNoteOp', () => {
     // initialize
     act(() => {
       result.current.setLines(['a', 'def']);
-      result.current.setPos({ ln: 1, col: 1 }); // d|ef
+      result.current.setPos({ ln: Ln(1), col: 1 }); // d|ef
     });
 
     await act(async () => {
@@ -83,7 +83,7 @@ describe('useNoteOp', () => {
     // initialize
     act(() => {
       result.current.setLines(['abc']);
-      result.current.setPos({ ln: 0, col: 2 }); // ab|c
+      result.current.setPos({ ln: Ln(0), col: 2 }); // ab|c
     });
 
     await act(async () => {
@@ -100,7 +100,7 @@ describe('useNoteOp', () => {
     // initialize
     act(() => {
       result.current.setLines(['abc', 'def']);
-      result.current.setPos({ ln: 1, col: 1 }); // d|ef
+      result.current.setPos({ ln: Ln(1), col: 1 }); // d|ef
     });
 
     await act(async () => {
@@ -116,7 +116,7 @@ describe('useNoteOp', () => {
     // initialize
     act(() => {
       result.current.setLines(['abc', 'def']);
-      result.current.setPos({ ln: 0, col: 2 }); // ab|c
+      result.current.setPos({ ln: Ln(0), col: 2 }); // ab|c
     });
 
     await act(async () => {
@@ -138,7 +138,7 @@ describe('useNoteOp', () => {
     // initialize
     act(() => {
       result.current.setLines(['abc', 'def']);
-      result.current.setPos({ ln: 0, col: 1 }); // a|bc
+      result.current.setPos({ ln: Ln(0), col: 1 }); // a|bc
     });
 
     await act(async () => {
@@ -166,7 +166,7 @@ describe('useNoteOp', () => {
     // initialize
     act(() => {
       result.current.setLines(['abc', 'def']);
-      result.current.setPos({ ln: 1, col: 1 }); // d|ef
+      result.current.setPos({ ln: Ln(1), col: 1 }); // d|ef
     });
 
     await act(async () => {
@@ -188,7 +188,7 @@ describe('useNoteOp', () => {
     // initialize
     act(() => {
       result.current.setLines(['abc']);
-      result.current.setPos({ ln: 0, col: 2 });
+      result.current.setPos({ ln: Ln(0), col: 2 });
     });
 
     await act(async () => {
@@ -204,7 +204,7 @@ describe('useNoteOp', () => {
     // initialize
     act(() => {
       result.current.setLines(['abc']);
-      result.current.setPos({ ln: 0, col: 0 });
+      result.current.setPos({ ln: Ln(0), col: 0 });
     });
 
     await act(async () => {
@@ -222,7 +222,7 @@ describe('new line', () => {
     // initialize
     act(() => {
       result.current.setLines(['aaaaa', 'bbbbb', 'ccccc']);
-      result.current.setPos({ ln: 1, col: 2 }); // bb|bbb
+      result.current.setPos({ ln: Ln(1), col: 2 }); // bb|bbb
     });
 
     await act(async () => {
@@ -233,7 +233,6 @@ describe('new line', () => {
       result.current.u.newLine();
       await waitForNextUpdate();
     });
-    console.log(result.current.focuedLine);
     expect(result.current.pos).toMatchObject({ ln: 2, col: 0 });
     expect(result.current.focuedLine).toBe('bbb');
     expect(result.current.lines).toStrictEqual([

--- a/packages/Reditor/src/Note/test/useNotOp.test.ts
+++ b/packages/Reditor/src/Note/test/useNotOp.test.ts
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react-hooks';
+import { act } from '@testing-library/react-hooks/dom';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { Ln, renderRecoilHook } from '../../Shared';
 import { cursorPosS } from '../../Cursor';

--- a/packages/Reditor/src/Note/useNoteOp.ts
+++ b/packages/Reditor/src/Note/useNoteOp.ts
@@ -3,7 +3,7 @@ import { useRecoilCallback } from 'recoil';
 import { useCursorKeymap, cursorColS, cursorLnS, cursorPosS } from '../Cursor';
 import { focuedLineS, useFocuedLine } from '../FocusedLine';
 import { decN } from '../Shared/functions';
-import { lineIdsS, noteLinesS, useLines } from '.';
+import { displayLids, noteLinesS, useLines } from '.';
 
 /**
  * useCursorKeymapとuseNoteの接続
@@ -87,7 +87,7 @@ export const useNoteOp = (noteId: number) => {
   const down = useRecoilCallback(
     ({ snapshot }) => async () => {
       const ln = await snapshot.getPromise(cursorLnS);
-      const lineIds = await snapshot.getPromise(lineIdsS(noteId));
+      const lineIds = await snapshot.getPromise(displayLids(noteId));
       if (ln + 1 < lineIds.length) {
         c.down();
       }

--- a/packages/Reditor/src/Shared/parsers/index.ts
+++ b/packages/Reditor/src/Shared/parsers/index.ts
@@ -4,9 +4,9 @@ import {
   StrongN,
   ItalicN,
   LinkN,
-  LineId,
   LineM,
   LineNodeM,
+  LineId,
 } from '../../Note';
 
 // -------------------------------------------------------------------------------------

--- a/packages/Reditor/src/Shared/test/recoilTest.tsx
+++ b/packages/Reditor/src/Shared/test/recoilTest.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react-hooks/dom';
 import React from 'react';
 import { RecoilRoot } from 'recoil';
 

--- a/packages/Reditor/src/Shared/typings.ts
+++ b/packages/Reditor/src/Shared/typings.ts
@@ -3,6 +3,11 @@
  * e.g. `hog|ehoge`の時, (0,3)
  */
 export type Pos = {
-  ln: number; // 0始まり、0行目, 1行目,..
+  ln: Ln; // 0始まり、0行目, 1行目,..
   col: number; // 0始まり. 0文字目の左, 1文字目の左,..
 };
+
+export type Ln = Branded<number, 'ln'>;
+export const Ln = (n: number) => n as Ln;
+
+export type Branded<T, U extends string> = T & { [key in U]: never };

--- a/packages/Reditor/src/components/Anchor.tsx
+++ b/packages/Reditor/src/components/Anchor.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { x } from '@xstyled/styled-components';
 import { Char } from './Char';
+import { Ln } from '../Shared';
 
 type Props = {
   value: string;
-  ln: number;
+  ln: Ln;
 };
 
 export const Anchor: React.VFC<Props> = ({ value, ln }) => (

--- a/packages/Reditor/src/components/Bold.tsx
+++ b/packages/Reditor/src/components/Bold.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { x } from '@xstyled/styled-components';
 import { Char } from './Char';
+import { Ln } from '../Shared';
 
 type Props = {
   value: string;
-  ln: number;
+  ln: Ln;
 };
 
 export const Bold: React.VFC<Props> = ({ value, ln }) => (

--- a/packages/Reditor/src/components/FocusedNotation.tsx
+++ b/packages/Reditor/src/components/FocusedNotation.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { CharType } from '../FocusedLine';
+import { Ln } from '../Shared';
 import { Char } from './Char';
 import { Cursor } from './Cursor';
 import { Space } from './Space';
@@ -8,7 +9,7 @@ import { Triangle } from './Triangle';
 type Props = {
   charType: CharType;
   index: number;
-  ln: number;
+  ln: Ln;
 };
 
 export const FocusedNotation: React.VFC<Props> = ({ charType, index, ln }) => {

--- a/packages/Reditor/src/components/Itaic.tsx
+++ b/packages/Reditor/src/components/Itaic.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { x } from '@xstyled/styled-components';
 import { Char } from './Char';
+import { Ln } from '../Shared';
 
 type Props = {
   value: string;
-  ln: number;
+  ln: Ln;
 };
 
 export const Italic: React.VFC<Props> = ({ value, ln }) => (

--- a/packages/Reditor/src/components/Line.tsx
+++ b/packages/Reditor/src/components/Line.tsx
@@ -4,9 +4,10 @@ import { useRecoilValue } from 'recoil';
 import { ViewLine } from './ViewLine';
 import { noteLineByLnS } from '../Note';
 import { cursorLnS } from '../Cursor';
+import { Ln } from '../Shared';
 
 type Props = {
-  ln: number;
+  ln: Ln;
 };
 
 export const Line: React.VFC<Props> = ({ ln }) => {

--- a/packages/Reditor/src/components/Normal.tsx
+++ b/packages/Reditor/src/components/Normal.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { x } from '@xstyled/styled-components';
 import { Char } from './Char';
+import { Ln } from '../Shared';
 
 type Props = {
   value: string;
-  ln: number;
+  ln: Ln;
 };
 
 export const Normal: React.VFC<Props> = ({ value, ln }) => (

--- a/packages/Reditor/src/components/Notation.tsx
+++ b/packages/Reditor/src/components/Notation.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { NotationM } from '../Note';
+import { Ln } from '../Shared';
 import { Anchor } from './Anchor';
 import { Bold } from './Bold';
 import { Italic } from './Itaic';
@@ -7,7 +8,7 @@ import { Normal } from './Normal';
 
 type Props = {
   notation: NotationM;
-  ln: number;
+  ln: Ln;
 };
 
 export const Notation: React.VFC<Props> = ({ notation, ln: lineIndex }) => {

--- a/packages/Reditor/src/components/TextLinets.tsx
+++ b/packages/Reditor/src/components/TextLinets.tsx
@@ -2,15 +2,16 @@ import React from 'react';
 import { x } from '@xstyled/styled-components';
 import { Node } from '.';
 import { useRecoilValue } from 'recoil';
-import { lineIdsS } from '../Note';
+import { displayLids } from '../Note';
+import { Ln } from '../Shared';
 
 export const TextLines: React.VFC = () => {
-  const lineIds = useRecoilValue(lineIdsS(0));
+  const lids = useRecoilValue(displayLids(0));
 
   return (
     <x.div>
-      {lineIds.map((id, index) => (
-        <Node key={id} ln={index} />
+      {lids.map((id, index) => (
+        <Node key={id} ln={Ln(index)} />
       ))}
     </x.div>
   );

--- a/packages/Reditor/src/components/ViewLine.tsx
+++ b/packages/Reditor/src/components/ViewLine.tsx
@@ -5,10 +5,11 @@ import { Notation } from './Notation';
 import { Empty } from './Empty';
 import { parseLine } from '../Shared/parsers';
 import { textStyle } from '../Shared/settings';
+import { Ln } from '../Shared';
 
 export type LineProps = {
   value: string;
-  ln: number;
+  ln: Ln;
 };
 
 export const ViewLine: React.VFC<LineProps> = ({ value, ln }) => {

--- a/packages/Reditor/src/components/index.tsx
+++ b/packages/Reditor/src/components/index.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Line } from './Line';
 import { x } from '@xstyled/styled-components';
+import { Ln } from '../Shared';
 
 type Props = {
-  ln: number;
+  ln: Ln;
 };
 
 export const Node: React.VFC<Props> = ({ ln }) => {


### PR DESCRIPTION
- 両方とも`number`のprimitive typeを使っていて、それが原因でバグっていたので、branded typesにしてみた